### PR TITLE
function for visit_occurrence_id covid19

### DIFF
--- a/src/main/python/util/__init__.py
+++ b/src/main/python/util/__init__.py
@@ -2,4 +2,4 @@ from .date_functions import get_datetime, get_end_datetime
 from .general_functions import is_null
 from .drug_quantity_functions import extract_numeric_quantity, valid_quantity_for_days_estimate
 from .code_cleanup import extend_read_code, add_dot_to_opcsx_code, refactor_icdx_code
-from .create_visit_id import create_hes_visit_occurrence_id, create_gp_visit_occurrence_id, create_covid_visit_occurrence_id, create_baseline_visit_occurrence_id, create_hes_visit_detail_id
+from .create_visit_id import create_hes_visit_occurrence_id, create_gp_visit_occurrence_id, create_covid_visit_occurrence_id, create_baseline_visit_occurrence_id, create_hes_visit_detail_id, create_gp_covid_visit_occurrence_id

--- a/src/main/python/util/create_visit_id.py
+++ b/src/main/python/util/create_visit_id.py
@@ -17,11 +17,11 @@ from typing import Optional
 
 from ..util import is_null
 
-
 BASELINE_PREFIX = '1'
 COVID_PREFIX = '2'
 HES_PREFIX = '3'
 GP_PREFIX = '4'
+GP_COVID_PREFIX = '5'
 
 
 def create_baseline_visit_occurrence_id(eid: str, instance: int) -> Optional[str]:
@@ -38,6 +38,10 @@ def create_hes_visit_occurrence_id(eid: str, spell_index: str) -> Optional[str]:
 
 def create_gp_visit_occurrence_id(eid: str, date: datetime) -> Optional[str]:
     return create_visit_occurrence_id(GP_PREFIX, eid, date.strftime('%Y%m%d'))
+
+
+def create_gp_covid_visit_occurrence_id(eid: str, date: datetime) -> Optional[str]:
+    return create_visit_occurrence_id(GP_COVID_PREFIX, eid, date.strftime('%Y%m%d'))
 
 
 def create_visit_occurrence_id(source_prefix: str, eid: str, index: str) -> Optional[str]:


### PR DESCRIPTION
Util functions now include a create_gp_covid_visit_occurrence_id with Prefix =5 for the new covid gp data.