### PR TITLE
batch transform covid19 tables

### DIFF
--- a/src/main/python/transformation/covid19_emis_gp_clinical_scripts_to_visit_occurrence.py
+++ b/src/main/python/transformation/covid19_emis_gp_clinical_scripts_to_visit_occurrence.py
@@ -41,5 +41,4 @@ def covid19_emis_gp_clinical_scripts_to_visit_occurrence(wrapper: Wrapper) -> Li
             visit_type_concept_id=32827,  # 'EHR encounter record'
             data_source='covid19 gp_emis'
         )
-        records.append(r)
-    return records
+        yield r

--- a/src/main/python/transformation/covid19_emis_gp_clinical_to_stem_table.py
+++ b/src/main/python/transformation/covid19_emis_gp_clinical_to_stem_table.py
@@ -75,7 +75,4 @@ def covid19_emis_gp_clinical_to_stem_table(wrapper: Wrapper) -> List[Wrapper.cdm
             value_as_number=row['value'],
             data_source='covid19 gp_emis'
         )
-        records.append(r)
-    return records
-
-
+        yield r

--- a/src/main/python/transformation/covid19_emis_gp_scripts_to_drug_exposure.py
+++ b/src/main/python/transformation/covid19_emis_gp_scripts_to_drug_exposure.py
@@ -55,6 +55,4 @@ def covid19_emis_gp_scripts_to_drug_exposure(wrapper: Wrapper) -> List[Wrapper.c
             data_source=data_source,
             visit_occurrence_id=visit_id,
         )
-        records.append(r)
-
-    return records
+        yield r

--- a/src/main/python/transformation/covid19_tpp_gp_clinical_scripts_to_visit_occurrence.py
+++ b/src/main/python/transformation/covid19_tpp_gp_clinical_scripts_to_visit_occurrence.py
@@ -41,5 +41,4 @@ def covid19_tpp_gp_clinical_scripts_to_visit_occurrence(wrapper: Wrapper) -> Lis
             visit_type_concept_id=32827,  # 'EHR encounter record'
             data_source='covid19 gp_tpp'
         )
-        records.append(r)
-    return records
+        yield r

--- a/src/main/python/transformation/covid19_tpp_gp_clinical_to_stem_table.py
+++ b/src/main/python/transformation/covid19_tpp_gp_clinical_to_stem_table.py
@@ -69,6 +69,4 @@ def covid19_tpp_gp_clinical_to_stem_table(wrapper: Wrapper) -> List[Wrapper.cdm.
             type_concept_id=32817,     # 32817: EHR
             data_source='covid19 gp_tpp'
         )
-        records.append(r)
-
-    return records
+        yield r

--- a/src/main/python/transformation/covid19_tpp_gp_scripts_to_drug_exposure.py
+++ b/src/main/python/transformation/covid19_tpp_gp_scripts_to_drug_exposure.py
@@ -49,6 +49,4 @@ def covid19_tpp_gp_scripts_to_drug_exposure(wrapper: Wrapper) -> List[Wrapper.cd
             data_source=data_source,
             visit_occurrence_id=visit_id
         )
-        records.append(r)
-
-    return records
+        yield r

--- a/src/main/python/wrapper.py
+++ b/src/main/python/wrapper.py
@@ -96,16 +96,17 @@ class Wrapper(BaseWrapper):
         self.execute_transformation(hesin_diag_to_condition_occurrence, bulk=True)
         self.execute_transformation(hesin_oper_to_procedure_occurrence, bulk=True)
         self.execute_transformation(cancer_register_to_condition_occurrence, bulk=True)
-        self.execute_transformation(covid19_emis_gp_clinical_to_stem_table, bulk=True)
+        self.execute_batch_transformation(covid19_emis_gp_clinical_to_stem_table, bulk=True, batch_size=100000)
 
         # New sets
-        self.execute_transformation(covid19_emis_gp_scripts_to_drug_exposure, bulk=True)
-        self.execute_transformation(covid19_tpp_gp_scripts_to_drug_exposure, bulk=True)
-        self.execute_transformation(covid19_tpp_gp_clinical_to_stem_table, bulk=True)
-        self.execute_transformation(covid19_emis_gp_clinical_scripts_to_visit_occurrence, bulk=True)
-        self.execute_transformation(covid19_tpp_gp_clinical_scripts_to_visit_occurrence, bulk=True)
+        self.execute_batch_transformation(covid19_emis_gp_scripts_to_drug_exposure, bulk=True, batch_size=100000)
+        self.execute_batch_transformation(covid19_tpp_gp_scripts_to_drug_exposure, bulk=True, batch_size=100000)
+        self.execute_batch_transformation(covid19_tpp_gp_clinical_to_stem_table, bulk=True, batch_size=100000)
+        self.execute_batch_transformation(covid19_emis_gp_clinical_scripts_to_visit_occurrence, bulk=True, batch_size=100000)
+        self.execute_batch_transformation(covid19_tpp_gp_clinical_scripts_to_visit_occurrence, bulk=True, batch_size=100000)
 
-        # CDM Source
+
+    # CDM Source
         self.execute_transformation(cdm_source, bulk=True)
 
         # Stem table to domains


### PR DESCRIPTION
Fix #296 

Transformations changed to batch:
- covid19_emis_gp_clinical_to_stem_table
- covid19_emis_gp_scripts_to_drug_exposure
- covid19_tpp_gp_scripts_to_drug_exposure
- covid19_tpp_gp_clinical_to_stem_table
- covid19_emis_gp_clinical_scripts_to_visit_occurrence
- covid19_tpp_gp_clinical_scripts_to_visit_occurrence

I added all the tables from covid19, and not only the ones that transform to stem_table, just in case. 
The batch_size is 100.000 for all.

The new code ran successfully with the synthetic data and passed the R tests, too.