### PR TITLE
allow icd codes <= 3

### DIFF
--- a/src/main/python/util/code_cleanup.py
+++ b/src/main/python/util/code_cleanup.py
@@ -26,8 +26,11 @@ def add_dot_to_opcsx_code(opcs_code: str) -> str:
 def refactor_icdx_code(icd_code: str) -> str:
     # Skip empty values
     if not is_null(icd_code):
+        # If code has 3 or less characters, return directly
+        if len(icd_code) <= 3:
+            return icd_code
         # A few specific exceptions who need a refactoring to XXX.X
-        if icd_code in ['2331', 'Y831', '72744', '72747', '75250', '72894', '73346', '75761', '75768',
+        elif icd_code in ['2331', 'Y831', '72744', '72747', '75250', '72894', '73346', '75761', '75768',
                         '49399', '25009', '59979', '38019', '62609', '72959', '79993', '71409']:
             return icd_code[:3] + '.' + icd_code[3:4]
         # Keep only the first three characters for ICD10 codes starting with W, X or Y.
@@ -41,7 +44,7 @@ def refactor_icdx_code(icd_code: str) -> str:
         elif icd_code[0] == 'V':
             return icd_code[:3] + '.' + icd_code[3]
         # General rule for remaining ICD codes is map to format XXX.X
-        elif len(icd_code) > 3 and not '.' in icd_code and icd_code != '45532996':
+        elif (not '.' in icd_code) and icd_code != '45532996':
             return icd_code[:3] + '.' + icd_code[3:4]
         else:
             return icd_code

--- a/src/test/R/test_cases/test_hes_diag_to_condition_occurrence.R
+++ b/src/test/R/test_cases/test_hes_diag_to_condition_occurrence.R
@@ -122,3 +122,12 @@ add_hesin(eid = 1015, ins_index = 1, admidate = '04/02/2021')
 add_hesin_diag(eid = 1015, ins_index = 1, diag_icd9 = '73346', diag_icd10 = '')
 expect_condition_occurrence(person_id = 1015, condition_start_date = '2021-02-04', condition_concept_id = 77650, condition_source_concept_id = 44830364)
 
+# Test small ICD10 code with V
+declareTest(1016, 'Test ICD10 code')
+add_baseline(eid = 1016)
+add_hesin(eid = 1016, ins_index = 1, admidate = '03/02/2021')
+add_hesin_diag(eid = 1016, ins_index = 1, diag_icd10 = 'V12')
+expect_condition_occurrence(person_id = 1016, condition_start_date = '2021-02-03', condition_concept_id = 433099, condition_source_concept_id = 45756179)
+
+
+


### PR DESCRIPTION
Fix #308 

Adding an extra if statement at the beginning of the loop in `code_cleanup.py` allows to return the original icd_code instead of `None` for short codes.

This returns a PASS in the new test case for the icd10 'V12'  -test #1016- (and icd9 '070', test #1001)