### PR TITLE
Release 1.4.0

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ from delphyne.util.io import read_yaml_file
 
 from src.main.python.wrapper import Wrapper
 
-__version__ = '1.4.0-SNAPSHOT'
+__version__ = '1.4.0'
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Release 1.4.0 fixes:
- Fix in short ICD codes #309 
- Several memory use improvements
- GP clinical follows domain target concept #113 
- Baseline field mapping to numeric and value #258 