### PR TITLE
More descriptive error message when failed loading vocabulary

### DIFF
--- a/src/main/python/wrapper.py
+++ b/src/main/python/wrapper.py
@@ -51,14 +51,13 @@ class Wrapper(BaseWrapper):
         # Load (custom) vocabularies and source_to_concept_map tables
         try:
             self.vocab_manager.standard_vocabularies.load()
-        except ValueError:
-            logger.warning('std vocab loading failed')
-            pass
+        except ValueError as e:
+            logger.warning(f'Standard vocabulary loading failed: {e.message}')
+
         try:
             self.vocab_manager.load_custom_vocab_and_stcm_tables()
-        except:
-            logger.warning('custom and stcm loading failed')
-            pass
+        except Exception as e:
+            logger.warning(f'Custom vocabulary and STCM loading failed: {e.message}')
 
         # Remove constraints and indexes to improve performance
         self.db.constraint_manager.drop_cdm_constraints()


### PR DESCRIPTION
Before, the only message was e.g.:
```
2021-08-09 18:31:07,910 - INFO - Loading standard vocabularies: True
2021-08-09 18:31:07,975 - WARNING - std vocab loading failed
```
The error thrown by delphyne has a good description. By adding that message debugging is easier.